### PR TITLE
Don't kill all local variables.

### DIFF
--- a/cuda-mode.el
+++ b/cuda-mode.el
@@ -326,7 +326,6 @@ initialization, then `cuda-mode-hook'.
 
 Key bindings:
 \\{cuda-mode-map}"
-  (kill-all-local-variables)
   (c-initialize-cc-mode t)
   (set-syntax-table cuda-mode-syntax-table)
   (setq local-abbrev-table cuda-mode-abbrev-table)


### PR DESCRIPTION
It is wrong to kill all local variables.  We can see in the cc-mode
code that it doesn't happen for c++-mode.

https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/cc-mode.el#L2784

This allows the modeline to be correct, too.