### PR TITLE
Pretend to be c++ mode after configuration.

### DIFF
--- a/cuda-mode.el
+++ b/cuda-mode.el
@@ -344,6 +344,7 @@ Key bindings:
   (run-hooks 'c++-mode-hook)
   (run-hooks 'cuda-mode-hook)
   (setq font-lock-keywords-case-fold-search t)
+  (setq c-buffer-is-cc-mode 'c++-mode)
   (c-update-modeline))
 
 (provide 'cuda-mode)


### PR DESCRIPTION
This is necessary because some of the code in cc-fonts.el checks the
mode to do formatting, for example, member initialization lists.

https://github.com/emacs-mirror/emacs/blob/783dd6da31e3f0387e110972c0b9fe1f5acc4bba/lisp/progmodes/cc-fonts.el#L1248

Before this change, formatting does this:

```cuda
class foo {
public:
  foo() :
  bar(3),
    baz(4),
    x(5) {}
};
```

Observe that the indentation of the member init list is not consistent.  Also, if you type `C-c C-o` on that line, you'll find that it thinks that the line is `topmost-intro`.  That is wrong.

After the change:

```cuda
class foo {
public:
  foo() :
    bar(3),
    baz(4),
    x(5) {}
};
```

Now they are lined up nicely.  And now that line is being indented as `member-init-intro`, which is correct for c++ and for cuda.